### PR TITLE
use ${{ runner.temp }} instead of mktemp

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Run pytest
       id: pytest
       run: |
-        REPORT="$(mktemp)"
+        REPORT="${{ runner.temp }}/raw_out"
         echo "report-path=$REPORT" >> $GITHUB_OUTPUT
         ${{ inputs.custom-pytest }}${{ inputs.verbose == 'true' && ' -v' || '' }}${{ inputs.job-summary == 'true' && ' --md=$REPORT' || '' }}${{ inputs.emoji == 'true' && ' --emoji' || '' }}${{ inputs.custom-arguments != '' && ' ' || '' }}${{ inputs.custom-arguments }}
       shell: bash -el {0}  # use login shell to source .bashrc for environments
@@ -48,7 +48,7 @@ runs:
       if: always() && inputs.job-summary == 'true'
       run: |
         echo "::group::..."
-        FINAL_REPORT="$(mktemp)"
+        FINAL_REPORT="${{ runner.temp }}/report_out"
         echo "# ${{ inputs.report-title }}" > "$FINAL_REPORT"
         if [ ${{ inputs.click-to-expand }} = true ]; then
           echo "<details><summary>Click to expand!</summary>" >> "$FINAL_REPORT"


### PR DESCRIPTION
`$(mktemp)` points to a file sitting in `$HOME` on windows, causing issue as the username is `RUNNER~1`, for example see https://github.com/Quantco/multiregex/actions/runs/9174534533/job/25225597689?pr=52